### PR TITLE
Only trigger a rebuild for the parlparse source

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,11 +1,11 @@
 require 'faraday'
 run -> env {
   body = [
-    'Northern_Ireland/Assembly',
+    'Northern-Ireland/Assembly',
     'Scotland/Parliament',
     'UK/Commons'
   ].map do |l|
-    Faraday.post("https://everypolitician-rebuilder.herokuapp.com/#{l}").body
+    Faraday.post("https://everypolitician-rebuilder.herokuapp.com/rebuild/#{l}/parlparse").body
   end
   [200, {}, body]
 }


### PR DESCRIPTION
Rather that rebuilding the entire legislature, switch to just rebuilding the `parlparse` source.

The change to Northern Ireland is because the `/rebuild` URL operates on slugs rather than directory paths.

Fixes #1 

# Notes to reviewer

There's no easy way to test this, but as the entire application is 11 lines long I don't think there should be any massive problems with this change. The main thing to check is that I've got the slugs correct for the countries and legislatures.

# Notes to merger

This app is set to auto-deploy to Heroku, so there _shouldn't_ be anything more needed, but it might be worth checking the "Recent deliveries" section of https://github.com/mysociety/parlparse/settings/hooks/6178593 at some point in the near future to ensure this change has worked.